### PR TITLE
Add ? to indicate bool

### DIFF
--- a/docs/authoring-components.md
+++ b/docs/authoring-components.md
@@ -88,7 +88,7 @@ As a reminder, variant properties will always appear above component properties 
 
 | Property name | Values |
 |--------|--------|
-| **leadingVisual** | `off` `on` | 
+| **leadingVisual?** | `on` `off` | 
 | **label?** | `true` `false` |
 | **state** | `rest` `focust` `hover` |
 | **visual** | `octicon` `avatar` |


### PR DESCRIPTION
@ashygee @langermank using `off` or `on` is only a different way of defining a boolean, correct? This means a property with those values should also have a `?` as a suffix.

Also resorted values to match logic below.