### PR TITLE
Add component issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---new-component-or-update.md
+++ b/.github/ISSUE_TEMPLATE/---new-component-or-update.md
@@ -1,0 +1,24 @@
+---
+name: "\U0001F4E6 New component or update"
+about: Suggest an new component or update
+title: ''
+labels: Component
+assignees: ''
+
+---
+
+**Does the component exist in any of the code implementations?**
+If it does, please add the links to the documentation page for all existing implementations.
+
+**Describe the use case**
+What will this component / update be used for?
+Is it already used?
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.
+
+**Have you built this in figma already or would you like to?**
+If you have build the component please add a figma link.


### PR DESCRIPTION
I think it would make sense to establish a workflow were components are requested / discussed before building via issues.

This allows us to track components, progress and feedback .