### PR TITLE
Bump Figma Docgen to v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@changesets/cli": "^2.25.2",
     "@changesets/types": "^5.2.1",
     "@manypkg/get-packages": "^1.1.3",
-    "@primer/figma-library-docgen": "^0.5.5",
+    "@primer/figma-library-docgen": "^0.6.0",
     "@types/node": "^18.11.18",
     "mdast-util-to-string": "^1.0.6",
     "remark-parse": "^7.0.1",


### PR DESCRIPTION
The new versions of Docgen adds better support for detecting default component variants and fixes an issue that makes the primer-brand library workflow fail.