### PR TITLE
Bump Figma Docgen to v0.6.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@changesets/cli": "^2.25.2",
         "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
-        "@primer/figma-library-docgen": "^0.6.3",
+        "@primer/figma-library-docgen": "^0.6.4",
         "@types/node": "^18.11.18",
         "mdast-util-to-string": "^1.0.6",
         "remark-parse": "^7.0.1",
@@ -583,9 +583,9 @@
       "link": true
     },
     "node_modules/@primer/figma-library-docgen": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@primer/figma-library-docgen/-/figma-library-docgen-0.6.3.tgz",
-      "integrity": "sha512-zmx0KY2nrTqJ/LF7cSBpVwqfnu5uUCeHpSsLB9ExMlAMjJeIcDVTwtyI2YI0fLCy9KWhW8habktlLRiWKpKTww==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@primer/figma-library-docgen/-/figma-library-docgen-0.6.4.tgz",
+      "integrity": "sha512-iGTYyEaM638+FLKhoa2LG5/9moMWKAXDKXW0sq5T4ZYsA88LtOkm8a51sWSJXEtcnTpvFnrSeShE5hFogvvCvQ==",
       "dev": true,
       "dependencies": {
         "axios": "^1.3.4",
@@ -5062,9 +5062,9 @@
       "version": "file:packages/interfaces"
     },
     "@primer/figma-library-docgen": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@primer/figma-library-docgen/-/figma-library-docgen-0.6.3.tgz",
-      "integrity": "sha512-zmx0KY2nrTqJ/LF7cSBpVwqfnu5uUCeHpSsLB9ExMlAMjJeIcDVTwtyI2YI0fLCy9KWhW8habktlLRiWKpKTww==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@primer/figma-library-docgen/-/figma-library-docgen-0.6.4.tgz",
+      "integrity": "sha512-iGTYyEaM638+FLKhoa2LG5/9moMWKAXDKXW0sq5T4ZYsA88LtOkm8a51sWSJXEtcnTpvFnrSeShE5hFogvvCvQ==",
       "dev": true,
       "requires": {
         "axios": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@changesets/cli": "^2.25.2",
     "@changesets/types": "^5.2.1",
     "@manypkg/get-packages": "^1.1.3",
-    "@primer/figma-library-docgen": "^0.6.3",
+    "@primer/figma-library-docgen": "^0.6.4",
     "@types/node": "^18.11.18",
     "mdast-util-to-string": "^1.0.6",
     "remark-parse": "^7.0.1",


### PR DESCRIPTION
Bumps Figma Docgen to the [latest version](https://github.com/primer/figma-docgen/releases/tag/v0.6.4), which fixes variant property duplication.