### PR TITLE
Bump figma-library-docgen to v0.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@changesets/cli": "^2.25.2",
     "@changesets/types": "^5.2.1",
     "@manypkg/get-packages": "^1.1.3",
-    "@primer/figma-library-docgen": "^0.6.4",
+    "@primer/figma-library-docgen": "^0.6.5",
     "@types/node": "^18.11.18",
     "mdast-util-to-string": "^1.0.6",
     "remark-parse": "^7.0.1",


### PR DESCRIPTION
This updated version of docgen prevents render timeout from the Figma REST API when fetching thumbnail images. This problem is currently happening in [Primer Brand generations](https://github.com/primer/figma/actions/runs/7403851130/job/20144417484).